### PR TITLE
Add popup action for the extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Tidy PR Timelines",
   "version": "1.0.0",
-  "author": "Andrea Caldera, Matt Woodage, Prabhat Thapa",
+  "author": "Andrea Caldera, Matt Woodage, Prabhat Thapa, Abhishek Gupta",
   "description": "Hide unwanted PR timeline events in GitHub",
   "manifest_version": 3,
   "content_scripts": [
@@ -12,6 +12,8 @@
     }
   ],
   "action": {
+    "default_title": "Hide GitHub PR Events",
+    "default_popup": "popup.html",
     "default_icon": {
       "32": "/images/32.png",
       "48": "/images/48.png",

--- a/popup.css
+++ b/popup.css
@@ -1,124 +1,124 @@
 /* Note: Styling copied from https://github.com/statsig-io/statsigstatus */
 
 * {
-    box-sizing: border-box;
-  }
-  
-  html {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    width: 500px;
-  }
-  body {
-    background-color: #f5f6f8;
-    color: #3b3b3b;
-    font-size: 14px;
-    font-weight: 300;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
-      "Helvetica Neue", "Ubuntu", sans-serif;
-    justify-content: center;
-    line-height: 22px;
-    margin: 0;
-    padding: 0;
-    text-align: center;
-    transition: opacity 0.3s;
-  }
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  footer {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
-      "Helvetica Neue", "Ubuntu", sans-serif;
-    line-height: 125%;
-  }
-  
-  h1 {
-    color: #3b3b3b;
-    font-size: 32px;
-    font-weight: bold;
-    margin: 0px;
-  }
-  h2 {
-    color: #3b3b3b;
-    font-size: 28px;
-    font-weight: bold;
-    margin: 16px 0 8px 0;
-  }
-  h3 {
-    color: #3b3b3b;
-    font-size: 24px;
-    font-weight: 700;
-    margin: 8px 0 4px 0;
-  }
-  h4 {
-    color: #3b3b3b;
-    font-size: 18px;
-    font-weight: 600;
-    margin-top: 5px;
-    margin-bottom: 4px;
-  }
-  h5 {
-    color: #3b3b3b;
-    font-size: 16px;
-    font-weight: bold;
-    margin-top: 5px;
-    margin-bottom: 4px;
-  }
-  h6 {
-    color: #3b3b3b;
-    font-size: 16px;
-    font-weight: bold;
-    margin-top: 5px;
-    margin-bottom: 4px;
-  }
-  a {
-    color: #194b7d;
-    text-decoration: none;
-  }
-  
-  footer {
-    color: #9c9c9c;
-    margin: 40px;
-  }
-  
-  footer a {
-    font-weight: bold;
-  }
-  
-  .container {
-    background-color: #fff;
-    box-shadow: 0px 6px 18px rgba(0, 0, 0, 0.06);
-    border-radius: 5px;
-    max-width: 900px;
-    width: 100%;
-    padding: 30px 20px;
-    margin: 0 auto 40px auto;
-  }
-  
-  .headline {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-  
-  .headline span {
-    background-color: #f5f6f8;
-    border-radius: 5px;
-    padding: 6px;
-    margin-left: 12px;
-    font-size: 16px;
-    font-weight: 700;
-    text-transform: uppercase;
-  }
-  
-  .filterContainer {
-    border: 1px solid #ededed;
-    border-radius: 5px;
-    padding-top: 20px;
-    text-align: left;
-    padding: 24px;
-  }
+  box-sizing: border-box;
+}
+
+html {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  width: 500px;
+}
+body {
+  background-color: #f5f6f8;
+  color: #3b3b3b;
+  font-size: 14px;
+  font-weight: 300;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Ubuntu',
+    sans-serif;
+  justify-content: center;
+  line-height: 22px;
+  margin: 0;
+  padding: 0;
+  text-align: center;
+  transition: opacity 0.3s;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+footer {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Ubuntu',
+    sans-serif;
+  line-height: 125%;
+}
+
+h1 {
+  color: #3b3b3b;
+  font-size: 32px;
+  font-weight: bold;
+  margin: 0px;
+}
+h2 {
+  color: #3b3b3b;
+  font-size: 28px;
+  font-weight: bold;
+  margin: 16px 0 8px 0;
+}
+h3 {
+  color: #3b3b3b;
+  font-size: 24px;
+  font-weight: 700;
+  margin: 8px 0 4px 0;
+}
+h4 {
+  color: #3b3b3b;
+  font-size: 18px;
+  font-weight: 600;
+  margin-top: 5px;
+  margin-bottom: 4px;
+}
+h5 {
+  color: #3b3b3b;
+  font-size: 16px;
+  font-weight: bold;
+  margin-top: 5px;
+  margin-bottom: 4px;
+}
+h6 {
+  color: #3b3b3b;
+  font-size: 16px;
+  font-weight: bold;
+  margin-top: 5px;
+  margin-bottom: 4px;
+}
+a {
+  color: #194b7d;
+  text-decoration: none;
+}
+
+footer {
+  color: #9c9c9c;
+  margin: 40px;
+}
+
+footer a {
+  font-weight: bold;
+}
+
+.container {
+  background-color: #fff;
+  box-shadow: 0px 6px 18px rgba(0, 0, 0, 0.06);
+  border-radius: 5px;
+  max-width: 900px;
+  width: 100%;
+  padding: 30px 20px;
+  margin: 0 auto 40px auto;
+}
+
+.headline {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.headline span {
+  background-color: #f5f6f8;
+  border-radius: 5px;
+  padding: 6px;
+  margin-left: 12px;
+  font-size: 16px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.filterContainer {
+  border: 1px solid #ededed;
+  border-radius: 5px;
+  padding-top: 20px;
+  text-align: left;
+  padding: 24px;
+}

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,124 @@
+/* Note: Styling copied from https://github.com/statsig-io/statsigstatus */
+
+* {
+    box-sizing: border-box;
+  }
+  
+  html {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    width: 500px;
+  }
+  body {
+    background-color: #f5f6f8;
+    color: #3b3b3b;
+    font-size: 14px;
+    font-weight: 300;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+      "Helvetica Neue", "Ubuntu", sans-serif;
+    justify-content: center;
+    line-height: 22px;
+    margin: 0;
+    padding: 0;
+    text-align: center;
+    transition: opacity 0.3s;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  footer {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+      "Helvetica Neue", "Ubuntu", sans-serif;
+    line-height: 125%;
+  }
+  
+  h1 {
+    color: #3b3b3b;
+    font-size: 32px;
+    font-weight: bold;
+    margin: 0px;
+  }
+  h2 {
+    color: #3b3b3b;
+    font-size: 28px;
+    font-weight: bold;
+    margin: 16px 0 8px 0;
+  }
+  h3 {
+    color: #3b3b3b;
+    font-size: 24px;
+    font-weight: 700;
+    margin: 8px 0 4px 0;
+  }
+  h4 {
+    color: #3b3b3b;
+    font-size: 18px;
+    font-weight: 600;
+    margin-top: 5px;
+    margin-bottom: 4px;
+  }
+  h5 {
+    color: #3b3b3b;
+    font-size: 16px;
+    font-weight: bold;
+    margin-top: 5px;
+    margin-bottom: 4px;
+  }
+  h6 {
+    color: #3b3b3b;
+    font-size: 16px;
+    font-weight: bold;
+    margin-top: 5px;
+    margin-bottom: 4px;
+  }
+  a {
+    color: #194b7d;
+    text-decoration: none;
+  }
+  
+  footer {
+    color: #9c9c9c;
+    margin: 40px;
+  }
+  
+  footer a {
+    font-weight: bold;
+  }
+  
+  .container {
+    background-color: #fff;
+    box-shadow: 0px 6px 18px rgba(0, 0, 0, 0.06);
+    border-radius: 5px;
+    max-width: 900px;
+    width: 100%;
+    padding: 30px 20px;
+    margin: 0 auto 40px auto;
+  }
+  
+  .headline {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  .headline span {
+    background-color: #f5f6f8;
+    border-radius: 5px;
+    padding: 6px;
+    margin-left: 12px;
+    font-size: 16px;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+  
+  .filterContainer {
+    border: 1px solid #ededed;
+    border-radius: 5px;
+    padding-top: 20px;
+    text-align: left;
+    padding: 24px;
+  }

--- a/popup.html
+++ b/popup.html
@@ -15,7 +15,7 @@
       <div>
         <p>
           This plugin filters certain Github PR events from the PR timeline
-          using below regex phases
+          using below regex phrases
         </p>
         <div class="filterContainer" id="filterData"></div>
       </div>

--- a/popup.html
+++ b/popup.html
@@ -14,17 +14,15 @@
       <hr />
       <div>
         <p>
-          This plugin filters certain Github PR events from the PR timeline
-          using below regex phrases
+          This plugin filters certain Github PR events from the PR timeline using below regex
+          phrases
         </p>
         <div class="filterContainer" id="filterData"></div>
       </div>
     </div>
     <footer>
       Powered by M&S.
-      <a
-        target="_blank"
-        href="https://github.com/marksandspencer/tidy-pr-timelines-extension"
+      <a target="_blank" href="https://github.com/marksandspencer/tidy-pr-timelines-extension"
         >Contribute here</a
       >
       |

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hide GitHub Events</title>
+    <link rel="stylesheet" href="popup.css" />
+    <script src="filters.js"></script>
+  </head>
+  <body>
+    <div class="container">
+      <div class="headline">
+        <img src="/images/32.png" alt="Logo" width="32px" />
+        <span> Hide GitHub PR Events </span>
+      </div>
+      <hr />
+      <div>
+        <p>
+          This plugin filters certain Github PR events from the PR timeline
+          using below regex phases
+        </p>
+        <div class="filterContainer" id="filterData"></div>
+      </div>
+    </div>
+    <footer>
+      Powered by M&S.
+      <a
+        target="_blank"
+        href="https://github.com/marksandspencer/tidy-pr-timelines-extension"
+        >Contribute here</a
+      >
+      |
+      <a
+        target="_blank"
+        href="https://github.com/marksandspencer/tidy-pr-timelines-extension/issues"
+        >Raise Issue</a
+      >
+    </footer>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,5 @@
 const getAllPhrases = () => {
-  return PHRASES_TO_HIDE.map((e) => `<h6>*${e}*</h6>`).join(" ");
-}
+  return PHRASES_TO_HIDE.map((e) => `<h6>*${e}*</h6>`).join(' ');
+};
 
-document.getElementById("filterData").innerHTML = getAllPhrases();
+document.getElementById('filterData').innerHTML = getAllPhrases();

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,5 @@
-const getAllPhases = () => {
+const getAllPhrases = () => {
   return PHRASES_TO_HIDE.map((e) => `<h6>*${e}*</h6>`).join(" ");
 }
 
-document.getElementById("filterData").innerHTML = getAllPhases();
+document.getElementById("filterData").innerHTML = getAllPhrases();

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,5 @@
+function getAllPhases() {
+  return PHRASES_TO_HIDE.map((e) => `<h6>*${e}*</h6>`).join(" ");
+}
+
+document.getElementById("filterData").innerHTML = getAllPhases();

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,4 @@
-function getAllPhases() {
+const getAllPhases = () => {
   return PHRASES_TO_HIDE.map((e) => `<h6>*${e}*</h6>`).join(" ");
 }
 


### PR DESCRIPTION
**Problem**
The extension does not show which phrases are filtered from GitHub PR events timeline

**Solution**
Add a popup action for the extension to show what phrases are filtered from the `filters.js` file

**Screenshot**
<img width="550" alt="Screenshot 2022-11-14 at 00 51 54" src="https://user-images.githubusercontent.com/6880622/201632632-6c258fa3-8798-4ee0-b96b-193a53e9b23b.png">
